### PR TITLE
Fixed Y Alignment of repo title banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ﻿<p align="center">
-  <a href="https://py-contributors.github.io/awesomeScripts/"><img src="https://capsule-render.vercel.app/api?type=rect&color=666666&height=100&section=header&text=Algorithms%20And%20Data%20Structures&fontSize=55%&fontColor=ffffff" alt="website title image"></a>
+  <a href="https://py-contributors.github.io/awesomeScripts/"><img src="https://capsule-render.vercel.app/api?type=rect&color=666666&height=100&section=header&text=Algorithms%20And%20Data%20Structures&fontSize=55%&fontColor=ffffff&fontAlignY=65" alt="website title image"></a>
   <h2 align="center">👉 A Collection of Algorithm And Data Structures in Cpp and Python 👈</h2>
 </p>
 


### PR DESCRIPTION
The Algorithms And DataStructure banner at the start of Readme.md was aligned to the top of the rectangle. Brought it to the center.

## Pull Request Template

### What have you Changed(must)
Readme.md Title Banner text alignment.

Creating a direct PR.

### README - [How to Contribute](https://github.com/Py-Contributors/AlgorithmsAndDataStructure/blob/master/CONTRIBUTING.md)
